### PR TITLE
Add option to specify machine id explicitly

### DIFF
--- a/lib/snowflake.ex
+++ b/lib/snowflake.ex
@@ -23,4 +23,12 @@ defmodule Snowflake do
   def next_id() do
     GenServer.call(Snowflake.Generator, :next_id)
   end
+
+  @doc """
+  Returns the machine id of the current node.
+  """
+  @spec machine_id() :: {:ok, integer}
+  def machine_id() do
+    GenServer.call(Snowflake.Generator, :machine_id)
+  end
 end

--- a/lib/snowflake/generator.ex
+++ b/lib/snowflake/generator.ex
@@ -23,6 +23,10 @@ defmodule Snowflake.Generator do
     end
   end
 
+  def handle_call(:machine_id, _from, {_epoch, _prev_ts, machine_id, _seq} = state) do
+    {:reply, {:ok, machine_id}, state}
+  end
+
   defp next_ts_and_seq(epoch, prev_ts, seq) do
     case ts(epoch) do
       ^prev_ts ->

--- a/lib/snowflake/helper.ex
+++ b/lib/snowflake/helper.ex
@@ -22,6 +22,11 @@ defmodule Snowflake.Helper do
   """
   @spec machine_id() :: integer
   def machine_id() do
+    id = Application.get_env(:snowflake, :machine_id)
+    machine_id(id)
+  end
+
+  defp machine_id(nil) do
     nodes = Application.get_env(:snowflake, :nodes) || @default_config[:nodes]
     host_addrs = [hostname(), fqdn(), Node.self()] ++ ip_addrs()
 
@@ -30,6 +35,9 @@ defmodule Snowflake.Helper do
       _ -> 1023
     end
   end
+
+  defp machine_id(id) when id >= 0 and id < 1024, do: id
+  defp machine_id(id), do: machine_id(nil)
 
   defp ip_addrs() do
     case :inet.getifaddrs do


### PR DESCRIPTION
The motivation behind this patch is to allow a config to specify an explicit machine id rather than having to rely on the node index mechanism.

This is useful in scenarios where different resources (e.g. non-Elixir system components) can also generate snowflakes.

There may also be cases whereby the devops of a system wants to specify the machine id rather than have be computed.

The semantics of this config is that if the machine id is specified, then that value will be used. If the machine id is not specified, this library will fallback to the nodes mechanism.