### PR TITLE
Modified the generated bitstring to conform to the specifications of snowflake

### DIFF
--- a/lib/snowflake/generator.ex
+++ b/lib/snowflake/generator.ex
@@ -49,7 +49,7 @@ defmodule Snowflake.Generator do
   defp create_id(ts, machine_id, seq) do
     << new_id :: unsigned-integer-size(64)>> = <<
        0 :: unsigned-integer-size(1),
-       ts :: unsigned-integer-size(42),
+       ts :: unsigned-integer-size(41),
        machine_id :: unsigned-integer-size(10),
        seq :: unsigned-integer-size(12) >>
 

--- a/lib/snowflake/generator.ex
+++ b/lib/snowflake/generator.ex
@@ -48,6 +48,7 @@ defmodule Snowflake.Generator do
 
   defp create_id(ts, machine_id, seq) do
     << new_id :: unsigned-integer-size(64)>> = <<
+       0 :: unsigned-integer-size(1),
        ts :: unsigned-integer-size(42),
        machine_id :: unsigned-integer-size(10),
        seq :: unsigned-integer-size(12) >>


### PR DESCRIPTION
The ID that is finally generated is 64 bits, but the ID generated in the process is time stamp (41 bits) machine ID (12 bits) sequence (12 bits) = 63 bits, with a leading zero. :smile: (I don't know scala well, but when I look at the source code, it looks like this. )