### PR TITLE
Remove deprecated Supervisor.Spec

### DIFF
--- a/lib/snowflake.ex
+++ b/lib/snowflake.ex
@@ -5,10 +5,8 @@ defmodule Snowflake do
   use Application
 
   def start(_type, _args) do
-    import Supervisor.Spec
-
     children = [
-      worker(Snowflake.Generator, [Snowflake.Helper.epoch(), Snowflake.Helper.machine_id()])
+      {Snowflake.Generator, [Snowflake.Helper.epoch(), Snowflake.Helper.machine_id()]}
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one)

--- a/lib/snowflake/generator.ex
+++ b/lib/snowflake/generator.ex
@@ -5,7 +5,7 @@ defmodule Snowflake.Generator do
   @machine_id_overflow 1024
   @seq_overflow 4096
 
-  def start_link(epoch, machine_id) when machine_id < @machine_id_overflow do
+  def start_link([epoch, machine_id]) when machine_id < @machine_id_overflow do
     state = {epoch, ts(epoch), machine_id, 0}
     GenServer.start_link(__MODULE__, state, name: __MODULE__)
   end


### PR DESCRIPTION
The current usage of `Supervisor` is deprecated, this PR updates it to the new version (and consequently silences the compile time warning in development)