### PR TITLE
import Config instead of the deprecated Mix.Config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :snowflake,
   nodes: ["127.0.0.1"],


### PR DESCRIPTION
`use Mix.Config` is deprecated and in development causes a warning. This PR replaces it with the new `import Config`